### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,25 +29,25 @@ To use your module in code, you will need to require it.
 
 ## API Properties
 
-###image
+### image
 
 Accepts a string path to a local file, or a TiBlob image object.
 
-###maxZoom
+### maxZoom
 
 Maximum zoom value, as a decimal. "5.5" means you can zoom in 550%
 
-###minZoom
+### minZoom
 
 Minimum zoom value, as a decimal. "0.5" means you can zoom out to 50%
 
-###zoom
+### zoom
 
 Zoom value for the view, as a decimal. Want to zoom to 300%? Set the value to 3.
 
 ## API Methods
 
-###createView(props)
+### createView(props)
 
 Accepts a dictonary of properties. TiTouchImageView extends TiUIView, so you can set other properties like top/left, backgroundColor, etc. Returns the view.
 

--- a/android/documentation/index.md
+++ b/android/documentation/index.md
@@ -25,25 +25,25 @@ To use your module in code, you will need to require it.
 
 ## API Properties
 
-###image
+### image
 
 Accepts a string path to a local file, or a TiBlob image object.
 
-###maxZoom
+### maxZoom
 
 Maximum zoom value, as a decimal. "5.5" means you can zoom in 550%
 
-###minZoom
+### minZoom
 
 Minimum zoom value, as a decimal. "0.5" means you can zoom out to 50%
 
-###zoom
+### zoom
 
 Zoom value for the view, as a decimal. Want to zoom to 300%? Set the value to 3.
 
 ## API Methods
 
-###createView(props)
+### createView(props)
 
 Accepts a dictonary of properties. TiTouchImageView extends TiUIView, so you can set other properties like top/left, backgroundColor, etc. Returns the view.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
